### PR TITLE
Support PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ dist: trusty
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
 
 # This triggers builds to run on the new TravisCI infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
@@ -15,11 +14,6 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
-
-matrix:
-  include:
-    - php: 5.6
-      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
 
 before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0"
+        "php": "^7.3|^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.4.3",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^2.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for PHP 8.0, but also drops support for unsupported PHP versions (earlier than 7.3).

It bumps dependencies to later versions for support and to keep up to date.

Closes #2.